### PR TITLE
Fix wrong capitalization of dynamic object field

### DIFF
--- a/ProfileAPI/Controllers/ProfileController.cs
+++ b/ProfileAPI/Controllers/ProfileController.cs
@@ -89,7 +89,7 @@ namespace ProfileAPI.Controllers
                         int x = 32 - profile.Id.Length;
                         graphID = new string('0', x) + profile.Id;
                     } else {
-                        graphID = profile.id;
+                        graphID = profile.Id;
                     }
                 
                     profileItem.Id = graphID;


### PR DESCRIPTION
Instead of `Id` the field was called as `id` which is not exists in this dynamic object, and cause to several exceptions in the service side.

Fixes #17